### PR TITLE
Disabled autofill in both edge and chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "rc-tooltip": "^5.2.2",
         "react": "^18.2.0",
         "react-chartjs-2": "^4.3.1",
+        "react-device-detect": "^2.2.2",
         "react-dom": "^18.2.0",
         "react-draggable": "^4.4.5",
         "react-no-ssr": "^1.1.0",
@@ -24790,6 +24791,18 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.2.tgz",
+      "integrity": "sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==",
+      "dependencies": {
+        "ua-parser-js": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.4.3.tgz",
@@ -27844,6 +27857,24 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.32.tgz",
+      "integrity": "sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/uglify-js": {
@@ -47727,6 +47758,14 @@
       "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-4.3.1.tgz",
       "integrity": "sha512-5i3mjP6tU7QSn0jvb8I4hudTzHJqS8l00ORJnVwI2sYu0ihpj83Lv2YzfxunfxTZkscKvZu2F2w9LkwNBhj6xA=="
     },
+    "react-device-detect": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.2.tgz",
+      "integrity": "sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==",
+      "requires": {
+        "ua-parser-js": "^1.0.2"
+      }
+    },
     "react-docgen": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.4.3.tgz",
@@ -50143,6 +50182,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.32.tgz",
+      "integrity": "sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rc-tooltip": "^5.2.2",
     "react": "^18.2.0",
     "react-chartjs-2": "^4.3.1",
+    "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-no-ssr": "^1.1.0",

--- a/src/components/Atoms/Config/InputBox.tsx
+++ b/src/components/Atoms/Config/InputBox.tsx
@@ -2,7 +2,7 @@ import { faFloppyDisk, faRotateRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import BeatLoader from 'react-spinners/BeatLoader';
-import { catchAsyncToString, parseintStrict } from 'utils/util';
+import { catchAsyncToString, DISABLE_AUTOFILL, parseintStrict } from 'utils/util';
 
 const onChangeValidateTimeout = 100;
 
@@ -227,7 +227,7 @@ export default function InputBox({
           }}
           disabled={disabled}
           type={type}
-          autoComplete="nope"
+          autoComplete={DISABLE_AUTOFILL}
         />
       </form>
     </div>

--- a/src/components/Atoms/Form/InputField.tsx
+++ b/src/components/Atoms/Form/InputField.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { at } from 'lodash';
 import { FieldHookConfig, useField } from 'formik';
+import { DISABLE_AUTOFILL } from 'utils/util';
 
 export type InputFieldProps = FieldHookConfig<string> & {
   label?: string;
@@ -32,7 +33,7 @@ export default function InputField(props: InputFieldProps) {
           onChange={field.onChange}
           onBlur={field.onBlur}
           name={field.name}
-          autoComplete="nope"
+          autoComplete={DISABLE_AUTOFILL}
           placeholder={props.placeholder}
         />
         {errorText && (

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -35,6 +35,7 @@ import {
   createInstanceFile,
   deleteInstanceDirectory,
   deleteInstanceFile,
+  DISABLE_AUTOFILL,
   downloadInstanceFiles,
   formatTimeAgo,
   saveInstanceFile,
@@ -532,7 +533,7 @@ export default function FileViewer() {
                 {({ isSubmitting }) => (
                   <Form
                     id="create-file-form"
-                    autoComplete="nope"
+                    autoComplete={DISABLE_AUTOFILL}
                     className="flex flex-col items-stretch gap-8 text-center"
                   >
                     <InputField
@@ -614,7 +615,7 @@ export default function FileViewer() {
                 {({ isSubmitting }) => (
                   <Form
                     id="create-folder-form"
-                    autoComplete="nope"
+                    autoComplete={DISABLE_AUTOFILL}
                     className="flex flex-col items-stretch gap-8 text-center"
                   >
                     <InputField

--- a/src/components/GameConsole.tsx
+++ b/src/components/GameConsole.tsx
@@ -8,6 +8,7 @@ import Tooltip from 'rc-tooltip';
 import { useContext, useEffect } from 'react';
 import { useRef, useState } from 'react';
 import { usePrevious } from 'utils/hooks';
+import { DISABLE_AUTOFILL } from 'utils/util';
 
 const autoScrollThreshold = 100;
 
@@ -152,7 +153,7 @@ export default function GameConsole() {
       <div className="font-mono text-small">
         <form
           noValidate
-          autoComplete="nope"
+          autoComplete={DISABLE_AUTOFILL}
           onSubmit={(e: React.SyntheticEvent) => {
             e.preventDefault();
             sendCommand(command);

--- a/src/pages/login/ConnectNewCorePage.tsx
+++ b/src/pages/login/ConnectNewCorePage.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Button from 'components/Atoms/Button';
 import { useContext } from 'react';
-import { errorToString, LODESTONE_PORT } from 'utils/util';
+import { DISABLE_AUTOFILL, errorToString, LODESTONE_PORT } from 'utils/util';
 import { CoreConnectionInfo, LodestoneContext } from 'data/LodestoneContext';
 import InputField from 'components/Atoms/Form/InputField';
 import { Form, Formik, FormikHelpers } from 'formik';
@@ -80,7 +80,7 @@ const ConnectNewCorePage = () => {
             <Form
               id="addCoreForm"
               className="flex flex-col gap-12"
-              autoComplete="nope"
+              autoComplete={DISABLE_AUTOFILL}
             >
               <div className="grid h-32 grid-cols-1 gap-y-14 gap-x-8 @lg:grid-cols-2">
                 <SelectField

--- a/src/pages/login/LoginNewUserPage.tsx
+++ b/src/pages/login/LoginNewUserPage.tsx
@@ -11,6 +11,7 @@ import { useCoreInfo } from 'data/SystemInfo';
 import NoSSR from 'react-no-ssr';
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 import { BrowserLocationContext } from 'data/BrowserLocationContext';
+import { DISABLE_AUTOFILL } from 'utils/util';
 
 type LoginValues = {
   username: string;
@@ -104,7 +105,7 @@ const LoginNewUserPage = () => {
             <Form
               id="loginForm"
               className="flex flex-col gap-12"
-              autoComplete="nope"
+              autoComplete={DISABLE_AUTOFILL}
             >
               <div className="grid h-32 grid-cols-1 gap-y-14 gap-x-8 @lg:grid-cols-2">
                 <InputField type="text" name="username" label="Username" />

--- a/src/pages/login/SelectCorePage.tsx
+++ b/src/pages/login/SelectCorePage.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import Button from 'components/Atoms/Button';
 import { useContext } from 'react';
-import { errorToString } from 'utils/util';
+import { DISABLE_AUTOFILL, errorToString } from 'utils/util';
 import { CoreConnectionInfo, LodestoneContext } from 'data/LodestoneContext';
 import { Form, Formik, FormikHelpers } from 'formik';
 import * as yup from 'yup';
@@ -93,7 +93,7 @@ const SelectCorePage = () => {
             <Form
               id="addCoreForm"
               className="flex flex-col gap-12"
-              autoComplete="nope"
+              autoComplete={DISABLE_AUTOFILL}
             >
               <div className="flex h-32 flex-row items-baseline gap-8">
                 <SelectCoreField

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,3 +1,4 @@
+import { isEdge } from 'react-device-detect';
 import { LabelColor } from 'components/Atoms/Label';
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 import { ClientError } from 'bindings/ClientError';
@@ -6,6 +7,7 @@ import { ClientFile } from 'bindings/ClientFile';
 import { QueryClient } from '@tanstack/react-query';
 import { Base64 } from 'js-base64';
 
+export const DISABLE_AUTOFILL = isEdge ? 'off-random-string-edge-stop-ignoring-autofill-off' : 'off';
 export const LODESTONE_PORT = 16662;
 
 export const capitalizeFirstLetter = (string: string) => {


### PR DESCRIPTION
Closes #47
The issue is actually not with Chrome but with Edge.
As far as I know, Edge is the only browser that ignores `autoComplete = "off"`

The `react-device-detect` library is added to detect Edge specifically, and set `autoComplete` to another random string, which disables auto complete on Edge.

An interesting note is that random string only disables auto complete on edge, but enables auto complete on other browsers.